### PR TITLE
Removal of warning spam when using Camera.Render (illegal accessing of cameraColorTarget)

### DIFF
--- a/Assets/Scripts/KawaseBlur.cs
+++ b/Assets/Scripts/KawaseBlur.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
@@ -102,6 +101,12 @@ public class KawaseBlur : ScriptableRendererFeature
             CommandBufferPool.Release(cmd);
         }
 
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        {
+            var src = renderingData.cameraData.renderer.cameraColorTarget;
+            Setup(src);
+        }
+
         public override void FrameCleanup(CommandBuffer cmd)
         {
         }
@@ -123,10 +128,6 @@ public class KawaseBlur : ScriptableRendererFeature
 
     public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
     {
-        var src = renderer.cameraColorTarget;
-        scriptablePass.Setup(src);
         renderer.EnqueuePass(scriptablePass);
     }
 }
-
-


### PR DESCRIPTION
This PR moves the accessing of cameraColorTarget to OnCameraSetup from AddRenderPasses to get rid of warning spam when using Camera.Render in another object.

Not sure when this became necessary, but it turns out the fix was relatively simple, so I thought I'd share.
I found out about this from this forum post: https://forum.unity.com/threads/azure-sky-dynamic-skybox.322773/page-27#post-6841583